### PR TITLE
fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,48 +1,24 @@
 [tool.poetry]
 name = "tsururu"
-description = "Python tool for time series forecasting"
 version = "0.1.0"
-
-authors = ["Alina Kostromina" <"AMaKostromina@sberbank.ru">,
-           "Dmitry Simakov" <"Simakov.D.E@sberbank.ru">]
-
+description = "Python tool for time series forecasting"
+authors = ["Alina Kostromina <AMaKostromina@sberbank.ru>", "Dmitry Simakov <Simakov.D.E@sberbank.ru>"]
+license = "Apache License 2.0"
 readme = "README.md"
 
-repository = "https://github.com/sberbank-ai-lab/tsururu"
-
-classifiers = [
-    "Programming Language :: Python :: 3.9",
-    "Operating System :: OS Independent",
-    "Intended Audience :: Science/Research",
-    "Development Status :: 2 - Pre-Alpha",
-    "Environment :: Console",
-    "Natural Language :: Russian",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
-]
-
 [tool.poetry.dependencies]
-
-python = ">=3.9"
-
-scikit-learn = "*"
-numpy = "*"
-pandas = "*"
-holidays = "*"
+python = "^3.9"
+scikit-learn = "^1.3.2"
+numpy = "^1.26.3"
+pandas = "^2.1.4"
+holidays = "^0.40"
 
 # models
-catboost = {version = "*", optional = true}
-
-[tool.poetry.extras]
-models = [
-    "catboost",
-]
+catboost = {version = "^1.2.2", optional = true}
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
-line-length = 99
-
-[tool.isort]
-profile = "black"
+[tool.poetry.extras]
+models = ["catboost"]


### PR DESCRIPTION
Generated pyproject.toml with the required library versions using poetry. Now pipeline:
```
pip install -U poetry
poetry lock
poetry install
```
is available. 