### PR TITLE
fix numpy type hints + fix series_to_series transformers

### DIFF
--- a/tsururu/dataset.py
+++ b/tsururu/dataset.py
@@ -13,7 +13,7 @@ class IndexSlicer:
     """
 
     @staticmethod
-    def timedelta(x: Tuple[NDArray[Union[np.int, np.float]], pd.Timedelta]):
+    def timedelta(x: Tuple[NDArray[Union[np.integer, np.floating]], pd.Timedelta]):
         """
         Returns the difference between neighboring observations
             in the array in terms of delta and the delta itself.
@@ -67,7 +67,7 @@ class IndexSlicer:
     @staticmethod
     def get_slice(
         data: pd.DataFrame,
-        k: Tuple[NDArray[np.int], NDArray[np.int]],
+        k: Tuple[NDArray[int], NDArray[int]],
     ) -> pd.DataFrame:
         """Get 3d slice.
 
@@ -118,14 +118,14 @@ class IndexSlicer:
         return ids
 
     def _rolling_window(
-        self, a: NDArray[np.float], window: int, step: int, from_last: bool = True
+        self, a: NDArray[np.floating], window: int, step: int, from_last: bool = True
     ):
         sliding_window = np.lib.stride_tricks.sliding_window_view(a, window)
-        return sliding_window[(len(a) - window) % step if from_last else 0:][::step]
+        return sliding_window[(len(a) - window) % step if from_last else 0 :][::step]
 
     def _create_idx_data(
         self,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
@@ -136,7 +136,7 @@ class IndexSlicer:
 
     def _create_idx_target(
         self,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
@@ -149,23 +149,23 @@ class IndexSlicer:
 
     def _create_idx_test(
         self,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
         _,
         __,
     ):
-        return self._rolling_window(np.arange(len(data)), history, step)[-(horizon + 1):-horizon]
+        return self._rolling_window(np.arange(len(data)), history, step)[-(horizon + 1) : -horizon]
 
     def _get_ids(
         self,
         func,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
-        ids: NDArray[np.int],
+        ids: NDArray[np.integer],
         cond: int = 0,
         n_last_horizon: Optional[int] = None,
     ):
@@ -185,11 +185,11 @@ class IndexSlicer:
 
     def create_idx_data(
         self,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
-        ids: Optional[NDArray[np.int]] = None,
+        ids: Optional[NDArray[np.integer]] = None,
         date_column: Optional[str] = None,
     ):
         """Find indices that, when applied to the original dataset,
@@ -224,11 +224,11 @@ class IndexSlicer:
 
     def create_idx_test(
         self,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
-        ids: Optional[NDArray[np.int]] = None,
+        ids: Optional[NDArray[np.integer]] = None,
         date_column: Optional[str] = None,
     ):
         """Find indices that, when applied to the original dataset,
@@ -263,11 +263,11 @@ class IndexSlicer:
 
     def create_idx_target(
         self,
-        data: NDArray[np.float],
+        data: NDArray[np.floating],
         horizon: int,
         history: int,
         step: int,
-        ids: Optional[NDArray[np.int]] = None,
+        ids: Optional[NDArray[np.integer]] = None,
         date_column: Optional[str] = None,
         n_last_horizon: Optional[int] = None,
     ):
@@ -368,21 +368,21 @@ class TSDataset:
         """
 
         def _crop_segment(
-            segment: NDArray[Union[np.float, np.str]],
+            segment: NDArray[Union[np.floating, np.str_]],
             test_last: bool,
-        ) -> NDArray[Union[np.float, np.str]]:
+        ) -> NDArray[Union[np.floating, np.str_]]:
             if test_last:
-                return segment[-self.history:]
-            return segment[-self.history - horizon:-horizon]
+                return segment[-self.history :]
+            return segment[-self.history - horizon : -horizon]
 
         def _pad_segment(
-            segment: NDArray[Union[np.float, np.str]],
+            segment: NDArray[Union[np.floating, np.str_]],
             horizon: int,
             time_delta: pd.Timedelta,
             date_col_id: Optional[int],
-            id_col_id: Optional[Union[str, NDArray[np.str]]],
-        ) -> NDArray[Union[np.float, np.str]]:
-            result = np.full((horizon, segment.shape[1]), None)
+            id_col_id: Optional[Union[str, NDArray[np.str_]]],
+        ) -> NDArray[Union[np.floating, np.str_]]:
+            result = np.full((horizon, segment.shape[1]), np.nan)
 
             last_date = segment[-1, date_col_id]
             new_dates = pd.date_range(last_date + time_delta, periods=horizon, freq=time_delta)
@@ -420,4 +420,9 @@ class TSDataset:
 
         # Concatenate together
         result = np.vstack(np.concatenate((segments, padded_segments_results), axis=1))
-        return pd.DataFrame(result, columns=columns)
+        result = pd.DataFrame(result, columns=columns)
+        result[self.date_column] = pd.to_datetime(result[self.date_column])
+        result[self.id_column] = result[self.id_column].astype("int")
+        other = [col for col in columns if col not in [self.id_column, self.date_column]]
+        result[other] = result[other].astype("float")
+        return result

--- a/tsururu/models.py
+++ b/tsururu/models.py
@@ -70,7 +70,7 @@ class Estimator:
             cv = TimeSeriesSplit(n_splits=self.validation_params["n_splits"])
         return cv
 
-    def fit(self, X: pd.DataFrame, y: NDArray[np.float]) -> None:
+    def fit(self, X: pd.DataFrame, y: NDArray[np.floating]) -> None:
         """Initialization and training of the model according to the
             passed parameters.
 
@@ -80,7 +80,7 @@ class Estimator:
         """
         raise NotImplementedError()
 
-    def predict(self, X: pd.DataFrame) -> NDArray[np.float]:
+    def predict(self, X: pd.DataFrame) -> NDArray[np.floating]:
         """Obtaining model predictions.
 
         Arguments:
@@ -101,7 +101,7 @@ class CatBoostRegressor_CV(Estimator):
     ):
         super().__init__(get_num_iterations, validation_params, model_params)
 
-    def fit(self, X: pd.DataFrame, y: NDArray[np.float]) -> None:
+    def fit(self, X: pd.DataFrame, y: NDArray[np.floating]) -> None:
         # Initialize cv object
         cv = self.initialize_validator()
 
@@ -151,7 +151,7 @@ class CatBoostRegressor_CV(Estimator):
         print(f"Mean {self.model_params['loss_function']}: {np.mean(self.scores).round(4)}")
         print(f"Std: {np.std(self.scores).round(4)}")
 
-    def predict(self, X: pd.DataFrame) -> NDArray[np.float]:
+    def predict(self, X: pd.DataFrame) -> NDArray[np.floating]:
         models_preds = [model.predict(X) for model in self.models]
         y_pred = np.mean(models_preds, axis=0)
         return y_pred

--- a/tsururu/strategies.py
+++ b/tsururu/strategies.py
@@ -151,8 +151,8 @@ class Strategy:
 
     @staticmethod
     def _make_multivariate_X_y(
-        X: pd.DataFrame, y: NDArray[np.float]
-    ) -> Tuple[pd.DataFrame, NDArray[np.float]]:
+        X: pd.DataFrame, y: NDArray[np.floating]
+    ) -> Tuple[pd.DataFrame, NDArray[np.floating]]:
         raise NotImplementedError()
 
     def _generate_X_y(
@@ -162,7 +162,7 @@ class Strategy:
         target_horizon: int,
         is_train: bool,
         history: str = None,
-        idx: Optional[NDArray[np.float]] = None,
+        idx: Optional[NDArray[np.floating]] = None,
         n_last_horizon: Optional[int] = None,
         X_only: bool = False,
     ):
@@ -177,7 +177,7 @@ class Strategy:
 
     def back_test(
         self, dataset: TSDataset, cv: int
-    ) -> Union[List, NDArray[Union[np.float, np.str]]]:
+    ) -> Union[List, NDArray[Union[np.floating, np.str_]]]:
         ids_list = []
         test_list = []
         preds_list = []
@@ -221,7 +221,7 @@ class Strategy:
         )
 
     @timing_decorator
-    def predict(self, dataset: TSDataset) -> NDArray[np.float]:
+    def predict(self, dataset: TSDataset) -> NDArray[np.floating]:
         raise NotImplementedError()
 
 
@@ -283,7 +283,7 @@ class RecursiveStrategy(Strategy):
         self,
         X: pd.DataFrame,
         date_column: "str",
-        y: Optional[NDArray[np.float]] = None,
+        y: Optional[NDArray[np.floating]] = None,
     ):
         idx_slicer = IndexSlicer()
 
@@ -337,7 +337,7 @@ class RecursiveStrategy(Strategy):
         target_horizon: int,
         is_train: bool,
         history: str = None,
-        idx: Optional[NDArray[np.float]] = None,
+        idx: Optional[NDArray[np.floating]] = None,
         n_last_horizon: Optional[int] = None,
         X_only: bool = False,
     ):
@@ -1148,7 +1148,7 @@ class FlatWideMIMOStrategy(MIMOStrategy):
         target_horizon: int,
         is_train: bool,
         history: str = None,
-        idx: Optional[NDArray[np.float]] = None,
+        idx: Optional[NDArray[np.floating]] = None,
         n_last_horizon: Optional[int] = None,
         X_only: bool = False,
     ):


### PR DESCRIPTION
1. Fix numpy type hints according to new version of numpy (np.int -> np.integer, np.float -> np.floating, np.str -> np.str_)
2. Fix transform and inverse_transform functions for segments according to new version of numpy (it needs to drop id index after apply)
3. In _pad_segment padding None has been replaced with np.nan, and further explicit types have been defined (datetime for date, int for id, float for everything else --> potentially need to convert to types from config)
4. Fix DifferenceTransformer: there was something wrong instead of cumsum and cumprod