### PR TITLE
Feature/exog

### DIFF
--- a/tests/test_exog/test_exog.py
+++ b/tests/test_exog/test_exog.py
@@ -1,0 +1,190 @@
+"""Tests for LagTransformer.from_target_date and future_exog pipeline integration."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from tsururu.dataset import TSDataset, IndexSlicer, Pipeline
+from tsururu.transformers.seq import LagTransformer
+
+
+N = 10
+HORIZON = 7
+HISTORY = 3
+
+index_slicer = IndexSlicer()
+
+
+def make_raw_dataframe(n=N):
+    dates = pd.date_range("2020-01-01", periods=n, freq="MS")
+    return pd.DataFrame(
+        {
+            "id": "0",
+            "timestamp": dates,
+            "target": np.arange(1.0, n + 1.0),
+            "exog_default_1": np.arange(1.0, 1.0 + n),
+            "exog_future": np.arange(100.0, 100.0 + n),
+        }
+    )
+
+
+COLUMNS_PARAMS = {
+    "target": {"columns": ["target"], "type": "continuous"},
+    "date": {"columns": ["timestamp"], "type": "datetime"},
+    "id": {"columns": ["id"], "type": "categorical"},
+    "exog_1": {"columns": ["exog_default_1"], "type": "continuous"},
+    "future_exog": {"columns": ["exog_future"], "type": "continuous"},
+}
+
+PIPELINE_PARAMS = {
+    "target": {
+        "columns": ["target"],
+        "features": {"LagTransformer": {"lags": [1, 2]}},
+    },
+    "date": {
+        "columns": ["timestamp"],
+        "features": {
+            "DateSeasonsGenerator": {"seasonalities": ["m"], "from_target_date": False},
+            "LagTransformer": {"lags": [1]},
+        },
+    },
+    "exog_future": {
+        "columns": ["exog_future"],
+        "features": {
+            "LagTransformer": {"lags": [1, 0], "from_target_date": True},
+        },
+    },
+    "exog_1": {
+        "columns": ["exog_default_1"],
+        "features": {
+            "LagTransformer": {"lags": [0], "from_target_date": False},
+        },
+    },
+}
+
+
+@pytest.fixture
+def dataset():
+    return TSDataset(make_raw_dataframe(), COLUMNS_PARAMS, print_freq_period_info=False)
+
+
+@pytest.fixture
+def data_dict(dataset):
+    features_idx = index_slicer.create_idx_data(
+        dataset.data, HORIZON, HISTORY, step=1,
+        date_column=dataset.date_column, delta=dataset.delta,
+    )
+    target_idx = index_slicer.create_idx_target(
+        dataset.data, HORIZON, HISTORY, step=1,
+        date_column=dataset.date_column, delta=dataset.delta,
+    )
+    return Pipeline.create_data_dict_for_pipeline(dataset, features_idx, target_idx)
+
+
+@pytest.fixture
+def fitted_pipeline(data_dict):
+    pipeline = Pipeline.from_dict(PIPELINE_PARAMS, multivariate=False)
+    pipeline.fit_transform(data_dict, strategy_name="MIMOStrategy")
+    return pipeline, data_dict
+
+
+def test_lag_from_target_date_anchors_at_idx_y():
+    """
+    from_target_date=True: якорь = idx_y[:, 0] (первый шаг горизонта).
+
+    idx_X[i] = [i, i+1, i+2] -> idx_X[:, -1] = [2, 3, 4, 5, 6, 7]
+    idx_y[i] = [i+3, i+4] -> idx_y[:, 0]  = [3, 4, 5, 6, 7, 8]
+
+    При lag=0: expected = exog_future[idx_y[:, 0]] = [103..108]
+    """
+    raw = pd.DataFrame({"exog_future": np.arange(100.0, 110.0)})
+    idx_X = np.array([[i, i + 1, i + 2] for i in range(6)])
+    idx_y = np.array([[i + 3, i + 4] for i in range(6)])
+
+    lag = LagTransformer(lags=[0], from_target_date=True)
+    lag.fit({"target_column_name": "_other_"}, ["exog_future"])
+
+    data = {
+        "raw_ts_X": raw,
+        "idx_X": idx_X,
+        "idx_y": idx_y,
+        "X": np.array([]),
+        "target_column_name": "_other_",
+    }
+    lag.generate(data)
+
+    # anchor = idx_y[:, 0] = [3,4,5,6,7,8] -> values [103..108]
+    expected = np.arange(103.0, 109.0).reshape(-1, 1)
+    np.testing.assert_array_equal(data["X"], expected)
+
+
+def test_lag_from_target_date_differs_from_idx_x_anchor():
+    """
+    from_target_date=True -> якорь idx_y[:, 0] → [103..108]
+    from_target_date=False -> якорь idx_X[:, -1] → [102..107]
+    """
+    raw = pd.DataFrame({"exog_future": np.arange(100.0, 110.0)})
+    idx_X = np.array([[i, i + 1, i + 2] for i in range(6)])
+    idx_y = np.array([[i + 3, i + 4] for i in range(6)])
+
+    base = {
+        "raw_ts_X": raw,
+        "idx_X": idx_X,
+        "idx_y": idx_y,
+        "target_column_name": "_other_",
+    }
+
+    lag_future = LagTransformer(lags=[0], from_target_date=True)
+    lag_future.fit({"target_column_name": "_other_"}, ["exog_future"])
+    data_future = {**base, "X": np.array([])}
+    lag_future.generate(data_future)
+
+    lag_normal = LagTransformer(lags=[0], from_target_date=False)
+    lag_normal.fit({"target_column_name": "_other_"}, ["exog_future"])
+    data_normal = {**base, "X": np.array([])}
+    lag_normal.generate(data_normal)
+
+    assert not np.array_equal(data_future["X"], data_normal["X"])
+    np.testing.assert_array_equal(data_future["X"].flatten(), np.arange(103.0, 109.0))
+    np.testing.assert_array_equal(data_normal["X"].flatten(), np.arange(102.0, 108.0))
+
+
+def test_future_exog_lag0_values_are_correct(fitted_pipeline):
+    """
+    exog_future__lag_0 при from_target_date=True:
+      anchor = idx_y[i, 0] = i + HISTORY
+      lag_0 = anchor - 0  = i + HISTORY
+      expected = 100 + i + HISTORY
+
+    При HISTORY=3, n_samples=1, i=0: expected = [103.0]
+    """
+    pipeline, data_dict = fitted_pipeline
+    X, _ = pipeline.generate(data_dict)
+
+    col_mask = pipeline.output_features == "exog_future__lag_0"
+    assert col_mask.sum() == 1
+
+    actual = X[:, col_mask].flatten()
+    n_samples = N - HISTORY - HORIZON + 1
+    expected = np.arange(100.0 + HISTORY, 100.0 + HISTORY + n_samples)  # [103.0]
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_future_exog_lag1_values_are_correct(fitted_pipeline):
+    """
+    exog_future__lag_1 при from_target_date=True:
+      anchor = idx_y[i, 0] = i + HISTORY
+      lag_1 = anchor - 1  = i + HISTORY - 1
+      expected = 100 + i + HISTORY - 1
+
+    При HISTORY=3, n_samples=1, i=0: expected = [102.0]
+    """
+    pipeline, data_dict = fitted_pipeline
+    X, _ = pipeline.generate(data_dict)
+
+    col_mask = pipeline.output_features == "exog_future__lag_1"
+    assert col_mask.sum() == 1
+
+    actual = X[:, col_mask].flatten()
+    n_samples = N - HISTORY - HORIZON + 1
+    expected = np.arange(100.0 + HISTORY - 1, 100.0 + HISTORY - 1 + n_samples)  # [102.0]
+    np.testing.assert_array_equal(actual, expected)

--- a/tsururu/dataset/dataset.py
+++ b/tsururu/dataset/dataset.py
@@ -95,13 +95,11 @@ class TSDataset:
         if reconstructed_data.shape[0] != self.data.shape[0] or not np.all(
             reconstructed_data == self.data[self.date_column].values
         ):
-            logger.warning(
-                f"""
-                It seems that the data is not regular. Please, check the data and the frequency info.                
+            logger.warning(f"""
+                It seems that the data is not regular. Please, check the data and the frequency info.
                 For multivariate regime it is critical to have regular data.
-                For global regime each regular part of time series will be processed as separate time series.           
-                """
-            )
+                For global regime each regular part of time series will be processed as separate time series.
+                """)
 
     def __init__(
         self,
@@ -166,7 +164,7 @@ class TSDataset:
         if test_last:
             return segment[-history:]
 
-        return segment[-history - horizon: -horizon]
+        return segment[-history - horizon : -horizon]
 
     @staticmethod
     def _pad_segment(
@@ -192,14 +190,12 @@ class TSDataset:
         result = np.full((horizon, segment.shape[1]), np.nan, dtype=object)
 
         last_date = segment[-1, date_col_id]
-        new_dates = pd.date_range(
-            last_date + time_delta, periods=horizon, freq=time_delta)
+        new_dates = pd.date_range(last_date + time_delta, periods=horizon, freq=time_delta)
         result[:, date_col_id] = new_dates
 
         if isinstance(id_col_id, np.ndarray):
             for i in range(len(id_col_id)):
-                result[:, id_col_id[i]] = np.repeat(
-                    segment[0, id_col_id[i]], horizon)
+                result[:, id_col_id[i]] = np.repeat(segment[0, id_col_id[i]], horizon)
         else:
             result[:, id_col_id] = np.repeat(segment[0, id_col_id], horizon)
 
@@ -254,8 +250,7 @@ class TSDataset:
                 step,
                 date_column=self.date_column,
             )
-            extended_data = slicer.get_slice(
-                self.data, (current_test_ids, None))
+            extended_data = slicer.get_slice(self.data, (current_test_ids, None))
             extended_data = pd.DataFrame(
                 extended_data.reshape(-1, extended_data.shape[-1]),
                 columns=self.data.columns,
@@ -281,8 +276,7 @@ class TSDataset:
         )
 
         if test_all:
-            ids = list(np.unique(extended_data.segment_col,
-                       return_index=True)[1])[1:]
+            ids = list(np.unique(extended_data.segment_col, return_index=True)[1])[1:]
 
         data = extended_data.to_numpy()
 
@@ -293,26 +287,22 @@ class TSDataset:
 
         # Find padded parts for each segment
         padded_segments_results = [
-            self._pad_segment(segment, horizon, time_delta,
-                              date_col_id, id_col_id)
+            self._pad_segment(segment, horizon, time_delta, date_col_id, id_col_id)
             for segment in segments
         ]
 
         # Concatenate together
-        result = np.vstack(np.concatenate(
-            (segments, padded_segments_results), axis=1))
+        result = np.vstack(np.concatenate((segments, padded_segments_results), axis=1))
         if test_all:
-            result = pd.DataFrame(
-                result, columns=list(columns) + ["segment_col"])
+            result = pd.DataFrame(result, columns=list(columns) + ["segment_col"])
         else:
             result = pd.DataFrame(result, columns=columns)
         result[self.date_column] = pd.to_datetime(result[self.date_column])
-        known_cols = {role_dict["columns"][0]
-                      for role_dict in self.columns_params.values()}
-        other = [col for col in columns if col not in [
-            self.id_column, self.date_column]]
+        known_cols = {role_dict["columns"][0] for role_dict in self.columns_params.values()}
+        other = [col for col in columns if col not in [self.id_column, self.date_column]]
         float_cols = [
-            col for col in other if col not in self.categorical_column and col in known_cols]
+            col for col in other if col not in self.categorical_column and col in known_cols
+        ]
         result[float_cols] = result[float_cols].astype("float")
 
         if df_future_exog is not None and self.future_exog_column:
@@ -368,8 +358,7 @@ class TSDataset:
                 dataset_data = dataset_data.copy()
                 dataset_data[col] = pd.NA
 
-        fe_dataset = future_exog[[id_column,
-                                  date_column] + future_exog_columns].copy()
+        fe_dataset = future_exog[[id_column, date_column] + future_exog_columns].copy()
         df = dataset_data.set_index([id_column, date_column])
         fe_idx = fe_dataset.set_index([id_column, date_column])
 

--- a/tsururu/dataset/dataset.py
+++ b/tsururu/dataset/dataset.py
@@ -29,8 +29,10 @@ class TSDataset:
                     "exog_1": {...},
                     "exog_2": {...},
                     ...,
-                    # TODO
-                    "future_exog": {"columns": ["col_future"]}
+                    "future_exog": {
+                        "columns": ["col_future"],
+                        "type": "continuous",
+                    },
                 }.
         delta: the pd.DateOffset class. Usually generated
             automatically, but can be externally specified. Needs to
@@ -125,7 +127,7 @@ class TSDataset:
                 data[column_name] = data[column_name].astype("float")
             elif column_type == "datetime":
                 data[column_name] = pd.to_datetime(data[column_name])
-            elif column_type == "future_exog":
+            elif column_name != "target" and column_type == "continuous":
                 self.future_exog_column.append(column_name)
             elif column_type == "categorical":
                 self.categorical_column.append(column_name)

--- a/tsururu/dataset/dataset.py
+++ b/tsururu/dataset/dataset.py
@@ -95,11 +95,13 @@ class TSDataset:
         if reconstructed_data.shape[0] != self.data.shape[0] or not np.all(
             reconstructed_data == self.data[self.date_column].values
         ):
-            logger.warning(f"""
+            logger.warning(
+                f"""
                 It seems that the data is not regular. Please, check the data and the frequency info.
                 For multivariate regime it is critical to have regular data.
                 For global regime each regular part of time series will be processed as separate time series.
-                """)
+                """
+                )
 
     def __init__(
         self,

--- a/tsururu/dataset/dataset.py
+++ b/tsururu/dataset/dataset.py
@@ -29,6 +29,8 @@ class TSDataset:
                     "exog_1": {...},
                     "exog_2": {...},
                     ...,
+                    # TODO
+                    "future_exog": {"columns": ["col_future"]}
                 }.
         delta: the pd.DateOffset class. Usually generated
             automatically, but can be externally specified. Needs to
@@ -74,6 +76,8 @@ class TSDataset:
             self.data[self.date_column], self.delta, return_freq_period_info=True
         )
 
+        self.delta = delta
+
         if print_freq_period_info:
             logger.info(info)
 
@@ -111,6 +115,9 @@ class TSDataset:
         self._auto_type_columns(columns_params, "id", "categorical")
         self._auto_type_columns(columns_params, "target", "continuous")
 
+        self.future_exog_column = []
+        self.categorical_column = []
+
         for _, role_dict in columns_params.items():
             column_name = role_dict["columns"][0]
             column_type = role_dict["type"]
@@ -118,6 +125,10 @@ class TSDataset:
                 data[column_name] = data[column_name].astype("float")
             elif column_type == "datetime":
                 data[column_name] = pd.to_datetime(data[column_name])
+            elif column_type == "future_exog":
+                self.future_exog_column.append(column_name)
+            elif column_type == "categorical":
+                self.categorical_column.append(column_name)
 
         self.data = data
         self.columns_params = columns_params
@@ -155,7 +166,7 @@ class TSDataset:
         if test_last:
             return segment[-history:]
 
-        return segment[-history - horizon : -horizon]
+        return segment[-history - horizon: -horizon]
 
     @staticmethod
     def _pad_segment(
@@ -181,12 +192,14 @@ class TSDataset:
         result = np.full((horizon, segment.shape[1]), np.nan, dtype=object)
 
         last_date = segment[-1, date_col_id]
-        new_dates = pd.date_range(last_date + time_delta, periods=horizon, freq=time_delta)
+        new_dates = pd.date_range(
+            last_date + time_delta, periods=horizon, freq=time_delta)
         result[:, date_col_id] = new_dates
 
         if isinstance(id_col_id, np.ndarray):
             for i in range(len(id_col_id)):
-                result[:, id_col_id[i]] = np.repeat(segment[0, id_col_id[i]], horizon)
+                result[:, id_col_id[i]] = np.repeat(
+                    segment[0, id_col_id[i]], horizon)
         else:
             result[:, id_col_id] = np.repeat(segment[0, id_col_id], horizon)
 
@@ -200,6 +213,7 @@ class TSDataset:
         test_all: bool = False,
         step: Optional[int] = None,
         id_column_name: Optional[Union[str, Sequence[str]]] = None,
+        df_future_exog: Optional[pd.DataFrame] = None,
     ):
         """Generate a test dataframe with new rows with NaN targets.
 
@@ -217,6 +231,11 @@ class TSDataset:
             id_column_name: name of the column(s) by which the data is
                 split (in some cases it is different from the originalß
                 id column(s)).
+            df_future_exog: optional dataframe with known future values
+                of exogenous variables. If provided and future_exog_column
+                is set, these values are inserted into the padded rows
+                for the corresponding columns.
+
 
         Notes:
             1. The new rows are filled with NaN target values,
@@ -235,7 +254,8 @@ class TSDataset:
                 step,
                 date_column=self.date_column,
             )
-            extended_data = slicer.get_slice(self.data, (current_test_ids, None))
+            extended_data = slicer.get_slice(
+                self.data, (current_test_ids, None))
             extended_data = pd.DataFrame(
                 extended_data.reshape(-1, extended_data.shape[-1]),
                 columns=self.data.columns,
@@ -261,7 +281,8 @@ class TSDataset:
         )
 
         if test_all:
-            ids = list(np.unique(extended_data.segment_col, return_index=True)[1])[1:]
+            ids = list(np.unique(extended_data.segment_col,
+                       return_index=True)[1])[1:]
 
         data = extended_data.to_numpy()
 
@@ -272,18 +293,85 @@ class TSDataset:
 
         # Find padded parts for each segment
         padded_segments_results = [
-            self._pad_segment(segment, horizon, time_delta, date_col_id, id_col_id)
+            self._pad_segment(segment, horizon, time_delta,
+                              date_col_id, id_col_id)
             for segment in segments
         ]
 
         # Concatenate together
-        result = np.vstack(np.concatenate((segments, padded_segments_results), axis=1))
+        result = np.vstack(np.concatenate(
+            (segments, padded_segments_results), axis=1))
         if test_all:
-            result = pd.DataFrame(result, columns=list(columns) + ["segment_col"])
+            result = pd.DataFrame(
+                result, columns=list(columns) + ["segment_col"])
         else:
             result = pd.DataFrame(result, columns=columns)
         result[self.date_column] = pd.to_datetime(result[self.date_column])
-        other = [col for col in columns if col not in [self.id_column, self.date_column]]
-        result[other] = result[other].astype("float")
+        known_cols = {role_dict["columns"][0]
+                      for role_dict in self.columns_params.values()}
+        other = [col for col in columns if col not in [
+            self.id_column, self.date_column]]
+        float_cols = [
+            col for col in other if col not in self.categorical_column and col in known_cols]
+        result[float_cols] = result[float_cols].astype("float")
+
+        if df_future_exog is not None and self.future_exog_column:
+            result = self.insert_future_exog(
+                result,
+                df_future_exog,
+                self.future_exog_column,
+                self.id_column,
+                self.date_column,
+            )
 
         return result
+
+    def insert_future_exog(
+        self,
+        dataset_data,
+        future_exog,
+        future_exog_columns,
+        id_column,
+        date_column,
+    ):
+        """Insert future exogenous variable values into the dataset.
+
+        Matches rows between dataset_data and future_exog by the
+        (id_column, date_column) pair and writes the exogenous values
+        into the corresponding positions.
+
+        Args:
+            dataset_data: original dataframe to insert exogenous values into.
+            future_exog: dataframe containing known future values of
+                exogenous variables.
+            future_exog_columns: list of column names to insert from
+                future_exog into dataset_data.
+            id_column: name of the column used to identify segments/entities.
+            date_column: name of the datetime column used for alignment.
+
+        Notes:
+            1. Columns listed in future_exog_columns that are missing from
+                dataset_data are added and initialised with pd.NA before
+                the update.
+            2. Row matching is performed on a (id_column, date_column)
+                multi-index, so both columns must have consistent types
+                across the two dataframes.
+            3. Existing non-NaN values in dataset_data are overwritten
+                where a matching row exists in future_exog.
+
+        Returns:
+            pd.DataFrame: a copy of dataset_data with future exogenous
+                values inserted for all matched (id, date) pairs.
+        """
+        for col in future_exog_columns:
+            if col not in dataset_data.columns:
+                dataset_data = dataset_data.copy()
+                dataset_data[col] = pd.NA
+
+        fe_dataset = future_exog[[id_column,
+                                  date_column] + future_exog_columns].copy()
+        df = dataset_data.set_index([id_column, date_column])
+        fe_idx = fe_dataset.set_index([id_column, date_column])
+
+        df.update(fe_idx, overwrite=True)
+        return df.reset_index()

--- a/tsururu/dataset/pipeline.py
+++ b/tsururu/dataset/pipeline.py
@@ -15,6 +15,7 @@ from tsururu.transformers import (
     Transformer,
     TransformersFactory,
     UnionTransformer,
+    LagTransformer,
 )
 
 transormers_factory = TransformersFactory()
@@ -32,11 +33,10 @@ class Pipeline:
     """
 
     def __init__(
-        self, transformers: Transformer, multivariate: bool = False, exog_transformer=None
+        self, transformers: Transformer, multivariate: bool = False,
     ):
         self.transformers = transformers
         self.multivariate = multivariate
-        self.exog_transformer = exog_transformer
 
         self.is_fitted = False
         self.strategy_name = None
@@ -62,7 +62,6 @@ class Pipeline:
         """
         # Resulting pipeline is a Union transformer with Sequential transformers
         result_union_transformers_list = []
-        exog_sequential_transformer = None
 
         # For each column create a list of transformers for resulting Sequential transformer
         for role, columns_params in columns_params.items():
@@ -89,21 +88,16 @@ class Pipeline:
 
                 current_sequential_transformers_list.append(transformer)
 
-            sequential = SequentialTransformer(
+            result_union_transformers_list.append(
+                SequentialTransformer(
                 transformers_list=current_sequential_transformers_list,
                 input_features=columns_params["columns"],
+                )
             )
-
-            if role == "exog":
-                # столбцы future_exog добавляются в X в исходном виде
-                # с помощью get_future_exog_futures;
-                exog_sequential_transformer = sequential
-            else:
-                result_union_transformers_list.append(sequential)
 
         union = UnionTransformer(transformers_list=result_union_transformers_list)
 
-        return cls(union, multivariate, exog_transformer=exog_sequential_transformer)
+        return cls(union, multivariate)
 
     @classmethod
     def easy_setup(cls, roles: dict, pipeline_params: dict, multivariate: bool) -> "Pipeline":
@@ -366,20 +360,17 @@ class Pipeline:
         """
         future_exog_columns = data["future_exog_columns"]
 
-        if self.exog_transformer is not None:
-            read_columns = list(self.exog_transformer.output_features)
-        else:
-            read_columns = future_exog_columns
-
         idx_y = data["idx_y"]
-        flat_idx = idx_y.reshape(-1)
-        future_vals = data["raw_ts_X"][read_columns].values[flat_idx].astype(float)
+        raw_vals = data["raw_ts_X"][future_exog_columns].values.astype(float)
 
-        if self.strategy_name in ("FlatWideMIMOStrategy", "recursive"):
-            return future_vals
+        if self.strategy_name == "recursive":
+            # onr value per sample
+            return raw_vals[idx_y[:, 0]]
+        elif self.strategy_name == "FlatWideMIMOStrategy":
+            return raw_vals[idx_y.reshape(-1)]
         elif self.strategy_name == "MIMOStrategy":
             N = idx_y.shape[0]
-            return future_vals.reshape(N, -1)
+            return raw_vals[idx_y.reshape(-1)].reshape(N, -1)
 
     def get_from_mimo_to_flatwidemimo_columns_names(
             self, data: dict, input_features: list
@@ -399,13 +390,13 @@ class Pipeline:
         """
         date_features_mask = np.array(
             [
-                bool(re.match(f"{data['date_column_name']}__", feature)) 
+                bool(re.match(f"{data['date_column_name']}__", feature))
                 for feature in input_features
             ]
         )
         id_features_mask = np.array(
             [
-                bool(re.match(f"{data['id_column_name']}__", feature)) 
+                bool(re.match(f"{data['id_column_name']}__", feature))
                 for feature in input_features
             ]
         )
@@ -473,7 +464,7 @@ class Pipeline:
 
         other_features_names = np.array(
             [
-                f"{feat}__{i}" 
+                f"{feat}__{i}"
                 for i, feat in product(range(data["num_series"]), other_features_names)
             ]
         )
@@ -515,6 +506,18 @@ class Pipeline:
             [bool(re.match(f"{data['id_column_name']}__", feature)) for feature in input_features]
         )
 
+        # exog -> "{future_exog_cols}__" in the beginning of the string
+        future_exog_cols = data.get("future_exog_columns") or []
+        if future_exog_cols:
+            future_exog_mask = np.array(
+                [
+                    bool(re.match(f"{col}__", feature)) for col in future_exog_cols
+                    for feature in input_features
+                ]
+            )
+        else:
+            future_exog_mask = np.zeros(len(input_features), dtype=bool)
+
         if self.strategy_name == "FlatWideMIMOStrategy":
             fh_mask = np.array([element == "FH" for element in input_features])
         else:
@@ -523,7 +526,7 @@ class Pipeline:
         # date -> "{date_column_name}__" in the beginning of the string
         date_mask = np.array(
             [
-                bool(re.match(f"{data['date_column_name']}__", feature)) 
+                bool(re.match(f"{data['date_column_name']}__", feature))
                 for feature in input_features
             ]
         )
@@ -538,7 +541,7 @@ class Pipeline:
 
         series_mask = np.logical_and(series_mask, ~(target_mask | cycle_mask))
 
-        other_mask = ~(target_mask | id_mask | fh_mask | date_mask | series_mask | cycle_mask)
+        other_mask = ~(target_mask | id_mask | fh_mask | date_mask | series_mask | cycle_mask | future_exog_mask)
 
         new_order_idx = np.concatenate(
             [
@@ -548,6 +551,7 @@ class Pipeline:
                 np.where(date_mask)[0],
                 np.where(series_mask)[0],
                 np.where(cycle_mask)[0],
+                np.where(future_exog_mask)[0],
                 np.where(other_mask)[0],
             ]
         )
@@ -559,6 +563,7 @@ class Pipeline:
             "datetime_features": np.sum(date_mask),
             "series_features": np.sum(series_mask),
             "cycle_features": np.sum(cycle_mask),
+            "future_exog_features": np.sum(future_exog_mask),
             "other_features": np.sum(other_mask),
         }
 
@@ -582,9 +587,6 @@ class Pipeline:
 
         """
         self.strategy_name = strategy_name
-
-        if self.exog_transformer is not None and data.get("future_exog_columns"):
-            data = self.exog_transformer.fit_transform(data)
 
         data = self.transformers.fit_transform(data)
         self.is_fitted = True
@@ -625,9 +627,6 @@ class Pipeline:
             the transformed data dictionary.
 
         """
-        if self.exog_transformer is not None and data.get("future_exog_columns"):
-            data = self.exog_transformer.transform(data)
-
         data = self.transformers.transform(data)
 
         return data
@@ -820,7 +819,7 @@ class Pipeline:
         other_features_colname = [
             col
             for col in X.columns.values
-            if col 
+            if col
             not in np.hstack([id_feature_colname, date_features_colname, fh_feature_colname])
         ]
 
@@ -899,6 +898,7 @@ class Pipeline:
 
         if self.future_exog_feature_names is not None and data.get("future_exog_columns"):
             future_X = self.get_future_exog_futures(data)
+            # future_X = future_X.reshape(1, -1)
             data["X"] = np.hstack([data["X"], future_X])
             current_features = np.concatenate([current_features, self.future_exog_feature_names])
 

--- a/tsururu/dataset/pipeline.py
+++ b/tsururu/dataset/pipeline.py
@@ -31,9 +31,10 @@ class Pipeline:
 
     """
 
-    def __init__(self, transformers: Transformer, multivariate: bool = False):
+    def __init__(self, transformers: Transformer, multivariate: bool = False, exog_transformer=None):
         self.transformers = transformers
         self.multivariate = multivariate
+        self.exog_transformer = exog_transformer
 
         self.is_fitted = False
         self.strategy_name = None
@@ -59,6 +60,7 @@ class Pipeline:
         """
         # Resulting pipeline is a Union transformer with Sequential transformers
         result_union_transformers_list = []
+        exog_sequential_transformer = None
 
         # For each column create a list of transformers for resulting Sequential transformer
         for role, columns_params in columns_params.items():
@@ -85,16 +87,21 @@ class Pipeline:
 
                 current_sequential_transformers_list.append(transformer)
 
-            result_union_transformers_list.append(
-                SequentialTransformer(
-                    transformers_list=current_sequential_transformers_list,
-                    input_features=columns_params["columns"],
-                )
+            sequential = SequentialTransformer(
+                transformers_list=current_sequential_transformers_list,
+                input_features=columns_params["columns"],
             )
+
+            if role == "exog":
+                # столбцы future_exog добавляются в X в исходном виде 
+                # с помощью get_future_exog_futures;
+                exog_sequential_transformer = sequential
+            else:
+                result_union_transformers_list.append(sequential)
 
         union = UnionTransformer(transformers_list=result_union_transformers_list)
 
-        return cls(union, multivariate)
+        return cls(union, multivariate, exog_transformer=exog_sequential_transformer)
 
     @classmethod
     def easy_setup(cls, roles: dict, pipeline_params: dict, multivariate: bool) -> "Pipeline":
@@ -357,9 +364,14 @@ class Pipeline:
         """
         future_exog_columns = data["future_exog_columns"]
 
+        if self.exog_transformer is not None:
+            read_columns = list(self.exog_transformer.output_features)
+        else:
+            read_columns = future_exog_columns
+
         idx_y = data["idx_y"]
         flat_idx = idx_y.reshape(-1)
-        future_vals = data["raw_ts_X"][future_exog_columns].values[flat_idx].astype(float)
+        future_vals = data["raw_ts_X"][read_columns].values[flat_idx].astype(float)
 
         if self.strategy_name in ("FlatWideMIMOStrategy", "recursive"):
             return future_vals
@@ -555,6 +567,9 @@ class Pipeline:
         """
         self.strategy_name = strategy_name
 
+        if self.exog_transformer is not None and data.get("future_exog_columns"):
+            data = self.exog_transformer.fit_transform(data)
+
         data = self.transformers.fit_transform(data)
         self.is_fitted = True
 
@@ -594,6 +609,9 @@ class Pipeline:
             the transformed data dictionary.
 
         """
+        if self.exog_transformer is not None and data.get("future_exog_columns"):
+            data = self.exog_transformer.transform(data)
+
         data = self.transformers.transform(data)
 
         return data

--- a/tsururu/dataset/pipeline.py
+++ b/tsururu/dataset/pipeline.py
@@ -42,6 +42,7 @@ class Pipeline:
 
         self.features_sort_idx = None
         self.features_groups = None
+        self.future_exog_feature_names = None
 
     @classmethod
     def from_dict(cls, columns_params: dict, multivariate: bool) -> "Pipeline":
@@ -302,8 +303,74 @@ class Pipeline:
         data["num_series"] = dataset.data[dataset.id_column].nunique()
         data["idx_X"] = features_idx
         data["idx_y"] = target_idx
+        data["future_exog_columns"] = dataset.future_exog_column
 
         return data
+    
+    def get_future_exog_feature_names(self, data):
+        """Generate feature names for future exogenous variables.
+
+        Builds a list of feature names based on the forecasting strategy.
+        For FlatWideMIMOStrategy and recursive strategies a single name
+        per column is produced; for MIMOStrategy a separate name is
+        generated for each horizon step.
+
+        Args:
+            data: dictionary containing:
+                - 'future_exog_columns': list of exogenous column names.
+                - 'idx_y': array of target indices with shape (N, horizon).
+
+        Returns:
+            np.ndarray: array of feature name strings.
+                - FlatWideMIMOStrategy / recursive: ``['{col}__future', ...]``
+                - MIMOStrategy: ``['{col}__future_{h}', ...]`` ordered by
+                horizon step first, then column.
+        """
+        future_exog_columns = data["future_exog_columns"]
+        horizon = data["idx_y"].shape[1]
+
+        if self.strategy_name in ("FlatWideMIMOStrategy", "recursive"):
+            names = [f"{col}__future" for col in future_exog_columns]
+        elif self.strategy_name == "MIMOStrategy":
+            names = [
+                f"{col}__future_{h}"
+                for h in range(horizon)
+                for col in future_exog_columns
+            ]
+        return np.array(names)
+        
+        
+    def get_future_exog_futures(self, data):
+        """
+        Extract future exogenous variable values aligned to target indices.
+
+        Retrieves the values of exogenous columns at the positions defined
+        by idx_y and reshapes them according to the forecasting strategy.
+
+        Args:
+            data: dictionary containing:
+                - 'future_exog_columns': list of exogenous column names.
+                - 'raw_ts_X': dataframe of input time-series features.
+                - 'idx_y': array of target indices with shape (N, horizon).
+
+        Returns:
+            np.ndarray:
+                - FlatWideMIMOStrategy / recursive: 2-D array of shape
+                (N * horizon, n_cols) with raw extracted values.
+                - MIMOStrategy: 2-D array of shape (N, horizon * n_cols)
+                with values reshaped per sample.
+        """
+        future_exog_columns = data["future_exog_columns"]
+        
+        idx_y = data["idx_y"]
+        flat_idx = idx_y.reshape(-1)
+        future_vals = data["raw_ts_X"][future_exog_columns].values[flat_idx].astype(float)
+
+        if self.strategy_name in ("FlatWideMIMOStrategy", "recursive"):
+            return future_vals
+        elif self.strategy_name == "MIMOStrategy":
+            N = idx_y.shape[0]
+            return future_vals.reshape(N, -1) 
 
     def get_from_mimo_to_flatwidemimo_columns_names(
         self, data: dict, input_features: list
@@ -518,6 +585,12 @@ class Pipeline:
             )
         if self.multivariate:
             current_features = self._get_multivariate_X_columns_names(data, current_features)
+
+        if (data.get("future_exog_columns")
+            and self.strategy_name in ("MIMOStrategy", "FlatWideMIMOStrategy", "recursive")
+        ):
+            self.future_exog_feature_names = self.get_future_exog_feature_names(data)
+            current_features = np.concatenate([current_features, self.future_exog_feature_names])
 
         self.features_sort_idx, self.features_groups = self.group_pipeline_output_features(
             data, current_features
@@ -806,6 +879,11 @@ class Pipeline:
                 )
             else:
                 data, current_features = self._make_multivariate_X_y(data, current_features)
+      
+        if self.future_exog_feature_names is not None and data.get("future_exog_columns"):
+            future_X = self.get_future_exog_futures(data)
+            data["X"] = np.hstack([data["X"], future_X])
+            current_features = np.concatenate([current_features, self.future_exog_feature_names])
 
         assert np.all(
             self.output_features == current_features[self.features_sort_idx]

--- a/tsururu/dataset/pipeline.py
+++ b/tsururu/dataset/pipeline.py
@@ -31,7 +31,9 @@ class Pipeline:
 
     """
 
-    def __init__(self, transformers: Transformer, multivariate: bool = False, exog_transformer=None):
+    def __init__(
+        self, transformers: Transformer, multivariate: bool = False, exog_transformer=None
+    ):
         self.transformers = transformers
         self.multivariate = multivariate
         self.exog_transformer = exog_transformer
@@ -93,7 +95,7 @@ class Pipeline:
             )
 
             if role == "exog":
-                # столбцы future_exog добавляются в X в исходном виде 
+                # столбцы future_exog добавляются в X в исходном виде
                 # с помощью get_future_exog_futures;
                 exog_sequential_transformer = sequential
             else:
@@ -379,7 +381,9 @@ class Pipeline:
             N = idx_y.shape[0]
             return future_vals.reshape(N, -1)
 
-    def get_from_mimo_to_flatwidemimo_columns_names(self, data: dict, input_features: list) -> list:
+    def get_from_mimo_to_flatwidemimo_columns_names(
+            self, data: dict, input_features: list
+        ) -> list:
         """
         Get the column names for the FlatWideMIMO strategy from MIMO format.
 
@@ -394,10 +398,16 @@ class Pipeline:
 
         """
         date_features_mask = np.array(
-            [bool(re.match(f"{data['date_column_name']}__", feature)) for feature in input_features]
+            [
+                bool(re.match(f"{data['date_column_name']}__", feature)) 
+                for feature in input_features
+            ]
         )
         id_features_mask = np.array(
-            [bool(re.match(f"{data['id_column_name']}__", feature)) for feature in input_features]
+            [
+                bool(re.match(f"{data['id_column_name']}__", feature)) 
+                for feature in input_features
+            ]
         )
         other_features_mask = ~(id_features_mask | date_features_mask)
 
@@ -462,7 +472,10 @@ class Pipeline:
         )
 
         other_features_names = np.array(
-            [f"{feat}__{i}" for i, feat in product(range(data["num_series"]), other_features_names)]
+            [
+                f"{feat}__{i}" 
+                for i, feat in product(range(data["num_series"]), other_features_names)
+            ]
         )
 
         return np.hstack([fh_features_names, date_features_names, other_features_names])
@@ -509,7 +522,10 @@ class Pipeline:
 
         # date -> "{date_column_name}__" in the beginning of the string
         date_mask = np.array(
-            [bool(re.match(f"{data['date_column_name']}__", feature)) for feature in input_features]
+            [
+                bool(re.match(f"{data['date_column_name']}__", feature)) 
+                for feature in input_features
+            ]
         )
 
         cycle_mask = np.array([bool(re.match(f"cycle_", feature)) for feature in input_features])
@@ -743,7 +759,9 @@ class Pipeline:
         other_features_idx = index_slicer.get_cols_idx(X, other_features_colname)
 
         segments_ids = np.append(
-            np.unique([tuple(x) for x in X[id_features_colname].values], axis=0, return_index=1)[1],
+            np.unique([tuple(x) for x in X[id_features_colname].values], axis=0, return_index=1)[
+                1
+            ],
             len(X),
         )
         segments_ids = np.sort(segments_ids)
@@ -802,7 +820,8 @@ class Pipeline:
         other_features_colname = [
             col
             for col in X.columns.values
-            if col not in np.hstack([id_feature_colname, date_features_colname, fh_feature_colname])
+            if col 
+            not in np.hstack([id_feature_colname, date_features_colname, fh_feature_colname])
         ]
 
         date_features_idx = index_slicer.get_cols_idx(X, date_features_colname)

--- a/tsururu/dataset/pipeline.py
+++ b/tsururu/dataset/pipeline.py
@@ -306,7 +306,7 @@ class Pipeline:
         data["future_exog_columns"] = dataset.future_exog_column
 
         return data
-    
+
     def get_future_exog_feature_names(self, data):
         """Generate feature names for future exogenous variables.
 
@@ -332,14 +332,9 @@ class Pipeline:
         if self.strategy_name in ("FlatWideMIMOStrategy", "recursive"):
             names = [f"{col}__future" for col in future_exog_columns]
         elif self.strategy_name == "MIMOStrategy":
-            names = [
-                f"{col}__future_{h}"
-                for h in range(horizon)
-                for col in future_exog_columns
-            ]
+            names = [f"{col}__future_{h}" for h in range(horizon) for col in future_exog_columns]
         return np.array(names)
-        
-        
+
     def get_future_exog_futures(self, data):
         """
         Extract future exogenous variable values aligned to target indices.
@@ -361,7 +356,7 @@ class Pipeline:
                 with values reshaped per sample.
         """
         future_exog_columns = data["future_exog_columns"]
-        
+
         idx_y = data["idx_y"]
         flat_idx = idx_y.reshape(-1)
         future_vals = data["raw_ts_X"][future_exog_columns].values[flat_idx].astype(float)
@@ -370,11 +365,9 @@ class Pipeline:
             return future_vals
         elif self.strategy_name == "MIMOStrategy":
             N = idx_y.shape[0]
-            return future_vals.reshape(N, -1) 
+            return future_vals.reshape(N, -1)
 
-    def get_from_mimo_to_flatwidemimo_columns_names(
-        self, data: dict, input_features: list
-    ) -> list:
+    def get_from_mimo_to_flatwidemimo_columns_names(self, data: dict, input_features: list) -> list:
         """
         Get the column names for the FlatWideMIMO strategy from MIMO format.
 
@@ -389,10 +382,7 @@ class Pipeline:
 
         """
         date_features_mask = np.array(
-            [
-                bool(re.match(f"{data['date_column_name']}__", feature))
-                for feature in input_features
-            ]
+            [bool(re.match(f"{data['date_column_name']}__", feature)) for feature in input_features]
         )
         id_features_mask = np.array(
             [bool(re.match(f"{data['id_column_name']}__", feature)) for feature in input_features]
@@ -435,10 +425,7 @@ class Pipeline:
 
         """
         date_features_names = input_features[
-            [
-                bool(re.match(f"{data['date_column_name']}__", feature))
-                for feature in input_features
-            ]
+            [bool(re.match(f"{data['date_column_name']}__", feature)) for feature in input_features]
         ]
         if self.strategy_name == "FlatWideMIMOStrategy":
             fh_features_names = np.array(["FH"])
@@ -463,10 +450,7 @@ class Pipeline:
         )
 
         other_features_names = np.array(
-            [
-                f"{feat}__{i}"
-                for i, feat in product(range(data["num_series"]), other_features_names)
-            ]
+            [f"{feat}__{i}" for i, feat in product(range(data["num_series"]), other_features_names)]
         )
 
         return np.hstack([fh_features_names, date_features_names, other_features_names])
@@ -513,10 +497,7 @@ class Pipeline:
 
         # date -> "{date_column_name}__" in the beginning of the string
         date_mask = np.array(
-            [
-                bool(re.match(f"{data['date_column_name']}__", feature))
-                for feature in input_features
-            ]
+            [bool(re.match(f"{data['date_column_name']}__", feature)) for feature in input_features]
         )
 
         cycle_mask = np.array([bool(re.match(f"cycle_", feature)) for feature in input_features])
@@ -586,8 +567,10 @@ class Pipeline:
         if self.multivariate:
             current_features = self._get_multivariate_X_columns_names(data, current_features)
 
-        if (data.get("future_exog_columns")
-            and self.strategy_name in ("MIMOStrategy", "FlatWideMIMOStrategy", "recursive")
+        if data.get("future_exog_columns") and self.strategy_name in (
+            "MIMOStrategy",
+            "FlatWideMIMOStrategy",
+            "recursive",
         ):
             self.future_exog_feature_names = self.get_future_exog_feature_names(data)
             current_features = np.concatenate([current_features, self.future_exog_feature_names])
@@ -742,9 +725,7 @@ class Pipeline:
         other_features_idx = index_slicer.get_cols_idx(X, other_features_colname)
 
         segments_ids = np.append(
-            np.unique([tuple(x) for x in X[id_features_colname].values], axis=0, return_index=1)[
-                1
-            ],
+            np.unique([tuple(x) for x in X[id_features_colname].values], axis=0, return_index=1)[1],
             len(X),
         )
         segments_ids = np.sort(segments_ids)
@@ -803,8 +784,7 @@ class Pipeline:
         other_features_colname = [
             col
             for col in X.columns.values
-            if col
-            not in np.hstack([id_feature_colname, date_features_colname, fh_feature_colname])
+            if col not in np.hstack([id_feature_colname, date_features_colname, fh_feature_colname])
         ]
 
         date_features_idx = index_slicer.get_cols_idx(X, date_features_colname)
@@ -879,7 +859,7 @@ class Pipeline:
                 )
             else:
                 data, current_features = self._make_multivariate_X_y(data, current_features)
-      
+
         if self.future_exog_feature_names is not None and data.get("future_exog_columns"):
             future_X = self.get_future_exog_futures(data)
             data["X"] = np.hstack([data["X"], future_X])

--- a/tsururu/strategies/recursive.py
+++ b/tsururu/strategies/recursive.py
@@ -208,7 +208,7 @@ class RecursiveStrategy(Strategy):
         horizon: int | None = None,
         test_all: bool = False,
         inverse_transform: bool = True,
-        df_future_exog = None
+        df_future_exog=None,
     ) -> pd.DataFrame:
         """Predicts the target values for the given dataset.
 
@@ -239,8 +239,11 @@ class RecursiveStrategy(Strategy):
         )
 
         new_data = dataset.make_padded_test(
-            intrinsic_horizon, self.history, test_all=test_all, step=self.step,
-            df_future_exog=df_future_exog
+            intrinsic_horizon,
+            self.history,
+            test_all=test_all,
+            step=self.step,
+            df_future_exog=df_future_exog,
         )
 
         new_dataset = TSDataset(new_data, dataset.columns_params, dataset.delta)

--- a/tsururu/strategies/recursive.py
+++ b/tsururu/strategies/recursive.py
@@ -208,6 +208,7 @@ class RecursiveStrategy(Strategy):
         horizon: int | None = None,
         test_all: bool = False,
         inverse_transform: bool = True,
+        df_future_exog = None
     ) -> pd.DataFrame:
         """Predicts the target values for the given dataset.
 
@@ -218,6 +219,9 @@ class RecursiveStrategy(Strategy):
                 Otherwise, predicts only the last window.
             inverse_transform (bool, default=True): if True, applies inverse transformations to the predictions
                 (e.g., reversing normalization/scaling).
+            df_future_exog: optional dataframe with known future values
+                of exogenous variables. Passed to make_padded_test and
+                inserted into the padded rows before inference.
 
         Returns:
             a pandas DataFrame containing the predicted target values.
@@ -235,7 +239,8 @@ class RecursiveStrategy(Strategy):
         )
 
         new_data = dataset.make_padded_test(
-            intrinsic_horizon, self.history, test_all=test_all, step=self.step
+            intrinsic_horizon, self.history, test_all=test_all, step=self.step,
+            df_future_exog=df_future_exog
         )
 
         new_dataset = TSDataset(new_data, dataset.columns_params, dataset.delta)

--- a/tsururu/transformers/seq.py
+++ b/tsururu/transformers/seq.py
@@ -28,12 +28,13 @@ class LagTransformer(SeriesToFeaturesTransformer):
 
     """
 
-    def __init__(self, lags: Union[int, Sequence[int]]):
+    def __init__(self, lags: Union[int, Sequence[int]], from_target_date: bool = False):
         super().__init__()
         if isinstance(lags, Sequence):
             self.lags = np.array(lags)
         if isinstance(lags, int):
             self.lags = np.arange(lags)
+        self.from_target_date = from_target_date
 
     def fit(self, data: dict, input_features: Sequence[str]) -> "LagTransformer":
         """Fit transformer on "elongated series" and return it's instance.
@@ -90,21 +91,34 @@ class LagTransformer(SeriesToFeaturesTransformer):
         Notes:
             1. Either both idx_X or idx_y must be specified,
                 LagTransformer uses only idx_X.
-
+            2. LagTransformer uses only idx_X; idx_y is used solely to
+            compute the horizon offset when from_target_date=True.
         """
         input_features_idx = index_slicer.get_cols_idx(data["raw_ts_X"], self.input_features)
 
-        if len(data["idx_X"].shape) == 3:
+        if self.from_target_date:
+            if len(data["idx_X"].shape) == 3:
+                raise NotImplementedError(
+                    "ПОКА LagTransformer с from_target_date=True не работает в multivariate"
+                )
+            horizon_offset = int(data["idx_y"][0, -1]) - int(data["idx_X"][0, -1])
+            anchor = data["idx_X"][:, -1] + horizon_offset 
+            lag_positions = anchor[:, np.newaxis] - self.lags[::-1]  
+            raw_values = data["raw_ts_X"].values
+            X = raw_values[lag_positions][:, :, input_features_idx].astype(float)
+            X = np.moveaxis(X, 1, 2).reshape(len(X), -1)
+        elif len(data["idx_X"].shape) == 3:
             self._check_lags_less_than_history(
                 data["raw_ts_X"], data["idx_X"][0], input_features_idx
             )
             X = _seq_mult_ts(data["raw_ts_X"], data["idx_X"], input_features_idx)
+            X = X[:, (X.shape[1] - 1) - self.lags[::-1], :]
+            X = np.moveaxis(X, 1, 2).reshape(len(X), -1)
         else:
             self._check_lags_less_than_history(data["raw_ts_X"], data["idx_X"], input_features_idx)
             X = index_slicer.get_slice(data["raw_ts_X"], (data["idx_X"], input_features_idx))
-
-        X = X[:, (X.shape[1] - 1) - self.lags[::-1], :]
-        X = np.moveaxis(X, 1, 2).reshape(len(X), -1)
+            X = X[:, (X.shape[1] - 1) - self.lags[::-1], :]
+            X = np.moveaxis(X, 1, 2).reshape(len(X), -1)
 
         if data["X"].shape == (0,):
             data["X"] = X

--- a/tsururu/transformers/seq.py
+++ b/tsururu/transformers/seq.py
@@ -51,6 +51,10 @@ class LagTransformer(SeriesToFeaturesTransformer):
         """
         super().fit(data, input_features)
 
+        assert not (
+            self.from_target_date and data["target_column_name"] in self.input_features
+        ), "from_target_date=True is not allowed for the target column"
+
         self.output_features = [
             f"{column}__lag_{lag}" for column, lag in product(self.input_features, self.lags[::-1])
         ]
@@ -101,8 +105,8 @@ class LagTransformer(SeriesToFeaturesTransformer):
                 raise NotImplementedError(
                     "ПОКА LagTransformer с from_target_date=True не работает в multivariate"
                 )
-            horizon_offset = int(data["idx_y"][0, -1]) - int(data["idx_X"][0, -1])
-            anchor = data["idx_X"][:, -1] + horizon_offset
+            # anchor = data["idx_y"][:, -1]
+            anchor = data["idx_y"][:, 0]
             lag_positions = anchor[:, np.newaxis] - self.lags[::-1]
             raw_values = data["raw_ts_X"].values
             X = raw_values[lag_positions][:, :, input_features_idx].astype(float)

--- a/tsururu/transformers/seq.py
+++ b/tsururu/transformers/seq.py
@@ -102,8 +102,8 @@ class LagTransformer(SeriesToFeaturesTransformer):
                     "ПОКА LagTransformer с from_target_date=True не работает в multivariate"
                 )
             horizon_offset = int(data["idx_y"][0, -1]) - int(data["idx_X"][0, -1])
-            anchor = data["idx_X"][:, -1] + horizon_offset 
-            lag_positions = anchor[:, np.newaxis] - self.lags[::-1]  
+            anchor = data["idx_X"][:, -1] + horizon_offset
+            lag_positions = anchor[:, np.newaxis] - self.lags[::-1]
             raw_values = data["raw_ts_X"].values
             X = raw_values[lag_positions][:, :, input_features_idx].astype(float)
             X = np.moveaxis(X, 1, 2).reshape(len(X), -1)


### PR DESCRIPTION
# Add future exogenous features support

Adds the ability to pass known-future exogenous variables to strategies at prediction time via a new `future_exog` column type and `df_future_exog` argument.

---

## Modified `tsururu/dataset/dataset.py`

- Added `future_exog` as a recognized column type in `TSDataset`
  - Columns with `type="future_exog"` are collected into `self.future_exog_column`
  - Columns with `type="categorical"` are collected into `self.categorical_column` (used to skip float-casting)
- Added `self.delta = delta` assignment so the value is always stored on the instance
- Extended `make_padded_test` with an optional `df_future_exog: Optional[pd.DataFrame]` parameter
  - After padding, calls `insert_future_exog` to fill padded rows with known future exog values
  - Float-casting now skips categorical columns
- Added `insert_future_exog(dataset_data, future_exog, future_exog_columns, id_column, date_column)`
  - Matches rows by `(id_column, date_column)` index pair using `pd.DataFrame.update`
  - Initialises missing exog columns with `pd.NA` before filling

## Modified `tsururu/dataset/pipeline.py`

- Added `self.future_exog_feature_names = None` to `Pipeline.__init__`
- `create_data_dict_for_pipeline` now passes `data["future_exog_columns"] = dataset.future_exog_column` into the data dict so downstream methods know which columns are future exog
- Added `get_future_exog_feature_names(data)` — builds feature name arrays:
  - `RecursiveStrategy` / `FlatWideMIMOStrategy`: one name per exog column (`col__future`)
  - `MIMOStrategy`: one name per (horizon step × exog column) pair (`col__future_h`)
- Added `get_future_exog_futures(data)` — extracts exog values from `raw_ts_X` at `idx_y` positions:
  - For Recursive/FlatWideMIMO: returns `(N, n_exog)` array (current-step values)
  - For MIMO: returns `(N, horizon × n_exog)` array (all future steps flattened)
- `fit_transform`: when `future_exog_columns` is non-empty and strategy is supported, appends future exog feature names to `current_features` and stores them in `self.future_exog_feature_names`
- `generate`: appends the actual future exog values to `data["X"]` via `np.hstack`

## Modified `tsururu/strategies/recursive.py`

- `RecursiveStrategy.predict` — added `df_future_exog: Optional[pd.DataFrame] = None` parameter
- Passes `df_future_exog` through to `dataset.make_padded_test` so padded rows are filled before the pipeline runs

## Modified `tsururu/transformers/seq.py`

- `LagTransformer.__init__` — added `from_target_date: bool = False` parameter
  - When `True`, lags are computed relative to the **target date** (`idx_y`) rather than the last feature date (`idx_X`), allowing date/exog features to be anchored to the forecast horizon
  - Lag positions: `anchor = idx_X[:, -1] + horizon_offset`, then `lag_positions = anchor - lags[::-1]`