### PR TITLE
docs(PyBoost): fix 'versbose' -> 'verbose' in model_params example

### DIFF
--- a/tsururu/models/boost.py
+++ b/tsururu/models/boost.py
@@ -77,7 +77,7 @@ class PyBoost(Estimator):
                 "loss": "mse",
                 "ntrees": 150000,
                 "es": 100,
-                "versbose": 1000
+                "verbose": 1000
             }.
 
     Notes:


### PR DESCRIPTION
## Summary

\`tsururu/models/boost.py\` \`PyBoost\` class docstring includes a \`model_params\` example that lists \`"versbose": 1000\`. The actual default set in \`fit_one_fold\` a few lines below uses the correct spelling \`"verbose"\`.

Closes #24

## Testing

Docstring-only change.